### PR TITLE
Add command line save loading

### DIFF
--- a/Unity/SaveGameData.cs
+++ b/Unity/SaveGameData.cs
@@ -43,4 +43,23 @@ public class SaveGameData
     {
         File.WriteAllText(path, JsonUtility.ToJson(current));
     }
+
+    public static bool TryLoadFromArgs()
+    {
+        var args = Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], "-load", StringComparison.OrdinalIgnoreCase))
+            {
+                var filePath = args[i + 1];
+                if (string.Equals(Path.GetExtension(filePath), ".mgdf", StringComparison.OrdinalIgnoreCase) && File.Exists(filePath))
+                {
+                    LoadFromFile(filePath);
+                    return true;
+                }
+                break;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- add TryLoadFromArgs to load a `.mgdf` save file when the `-load <path>` command-line argument is provided

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a23d25288330952fe0898ebddb0f