### PR TITLE
Add SaveGameData scripts for Godot and Unreal

### DIFF
--- a/Godot/SaveGameData.gd
+++ b/Godot/SaveGameData.gd
@@ -1,0 +1,68 @@
+extends RefCounted
+class_name SaveGameData
+
+var integer_one:int
+var integer_two:int
+var integer_three:int
+var integer_four:int
+var float_one:float
+var float_two:float
+var float_three:float
+var vector_one:Vector3
+var vector_two:Vector3
+
+static var current:SaveGameData
+
+static func load_from_file(path:String) -> void:
+    if not FileAccess.file_exists(path):
+        return
+    var file = FileAccess.open(path, FileAccess.READ)
+    if file:
+        var data = JSON.parse_string(file.get_as_text())
+        file.close()
+        if typeof(data) == TYPE_DICTIONARY:
+            var d:Dictionary = data
+            current = SaveGameData.new()
+            current.integer_one = d.get("integer_one", 0)
+            current.integer_two = d.get("integer_two", 0)
+            current.integer_three = d.get("integer_three", 0)
+            current.integer_four = d.get("integer_four", 0)
+            current.float_one = d.get("float_one", 0.0)
+            current.float_two = d.get("float_two", 0.0)
+            current.float_three = d.get("float_three", 0.0)
+            var v1 = d.get("vector_one", {})
+            if v1 is Dictionary:
+                current.vector_one = Vector3(v1.get("x", 0), v1.get("y", 0), v1.get("z", 0))
+            var v2 = d.get("vector_two", {})
+            if v2 is Dictionary:
+                current.vector_two = Vector3(v2.get("x", 0), v2.get("y", 0), v2.get("z", 0))
+
+static func save_to_file(path:String) -> void:
+    if current == null:
+        return
+    var data = {
+        "integer_one": current.integer_one,
+        "integer_two": current.integer_two,
+        "integer_three": current.integer_three,
+        "integer_four": current.integer_four,
+        "float_one": current.float_one,
+        "float_two": current.float_two,
+        "float_three": current.float_three,
+        "vector_one": {"x": current.vector_one.x, "y": current.vector_one.y, "z": current.vector_one.z},
+        "vector_two": {"x": current.vector_two.x, "y": current.vector_two.y, "z": current.vector_two.z},
+    }
+    var file = FileAccess.open(path, FileAccess.WRITE)
+    if file:
+        file.store_string(JSON.stringify(data))
+        file.close()
+
+static func try_load_from_args() -> bool:
+    var args = OS.get_cmdline_args()
+    for i in range(args.size() - 1):
+        if args[i].to_lower() == "-load":
+            var file_path = args[i + 1]
+            if file_path.get_extension().to_lower() == "mgdf" and FileAccess.file_exists(file_path):
+                load_from_file(file_path)
+                return true
+            break
+    return false

--- a/Unreal/SaveGameData.cpp
+++ b/Unreal/SaveGameData.cpp
@@ -1,0 +1,99 @@
+#include "SaveGameData.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Misc/CommandLine.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+USaveGameData* USaveGameData::Current = nullptr;
+
+void USaveGameData::LoadFromFile(const FString& Path)
+{
+    FString Content;
+    if (FFileHelper::LoadFileToString(Content, *Path))
+    {
+        TSharedPtr<FJsonObject> JsonObject;
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+        if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+        {
+            USaveGameData* Data = NewObject<USaveGameData>();
+            Data->integer_one = JsonObject->GetIntegerField(TEXT("integer_one"));
+            Data->integer_two = JsonObject->GetIntegerField(TEXT("integer_two"));
+            Data->integer_three = JsonObject->GetIntegerField(TEXT("integer_three"));
+            Data->integer_four = JsonObject->GetIntegerField(TEXT("integer_four"));
+            Data->float_one = JsonObject->GetNumberField(TEXT("float_one"));
+            Data->float_two = JsonObject->GetNumberField(TEXT("float_two"));
+            Data->float_three = JsonObject->GetNumberField(TEXT("float_three"));
+
+            const TSharedPtr<FJsonObject>* VecObj;
+            if (JsonObject->TryGetObjectField(TEXT("vector_one"), VecObj))
+            {
+                Data->vector_one.X = (*VecObj)->GetNumberField(TEXT("x"));
+                Data->vector_one.Y = (*VecObj)->GetNumberField(TEXT("y"));
+                Data->vector_one.Z = (*VecObj)->GetNumberField(TEXT("z"));
+            }
+            if (JsonObject->TryGetObjectField(TEXT("vector_two"), VecObj))
+            {
+                Data->vector_two.X = (*VecObj)->GetNumberField(TEXT("x"));
+                Data->vector_two.Y = (*VecObj)->GetNumberField(TEXT("y"));
+                Data->vector_two.Z = (*VecObj)->GetNumberField(TEXT("z"));
+            }
+            Current = Data;
+        }
+    }
+}
+
+void USaveGameData::SaveToFile(const FString& Path)
+{
+    if (!Current)
+    {
+        return;
+    }
+
+    TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
+    JsonObject->SetNumberField(TEXT("integer_one"), Current->integer_one);
+    JsonObject->SetNumberField(TEXT("integer_two"), Current->integer_two);
+    JsonObject->SetNumberField(TEXT("integer_three"), Current->integer_three);
+    JsonObject->SetNumberField(TEXT("integer_four"), Current->integer_four);
+    JsonObject->SetNumberField(TEXT("float_one"), Current->float_one);
+    JsonObject->SetNumberField(TEXT("float_two"), Current->float_two);
+    JsonObject->SetNumberField(TEXT("float_three"), Current->float_three);
+
+    TSharedPtr<FJsonObject> VecObj = MakeShareable(new FJsonObject);
+    VecObj->SetNumberField(TEXT("x"), Current->vector_one.X);
+    VecObj->SetNumberField(TEXT("y"), Current->vector_one.Y);
+    VecObj->SetNumberField(TEXT("z"), Current->vector_one.Z);
+    JsonObject->SetObjectField(TEXT("vector_one"), VecObj);
+
+    VecObj = MakeShareable(new FJsonObject);
+    VecObj->SetNumberField(TEXT("x"), Current->vector_two.X);
+    VecObj->SetNumberField(TEXT("y"), Current->vector_two.Y);
+    VecObj->SetNumberField(TEXT("z"), Current->vector_two.Z);
+    JsonObject->SetObjectField(TEXT("vector_two"), VecObj);
+
+    FString Output;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Output);
+    FJsonSerializer::Serialize(JsonObject.ToSharedRef(), Writer);
+    FFileHelper::SaveStringToFile(Output, *Path);
+}
+
+bool USaveGameData::TryLoadFromArgs()
+{
+    TArray<FString> Args;
+    FString(FCommandLine::Get()).ParseIntoArrayWS(Args);
+    for (int32 i = 0; i < Args.Num() - 1; ++i)
+    {
+        if (Args[i].Equals(TEXT("-load"), ESearchCase::IgnoreCase))
+        {
+            FString FilePath = Args[i + 1];
+            if (FPaths::GetExtension(FilePath).Equals(TEXT("mgdf"), ESearchCase::IgnoreCase) && FPaths::FileExists(FilePath))
+            {
+                LoadFromFile(FilePath);
+                return true;
+            }
+            break;
+        }
+    }
+    return false;
+}

--- a/Unreal/SaveGameData.h
+++ b/Unreal/SaveGameData.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+#include "SaveGameData.generated.h"
+
+UCLASS()
+class USaveGameData : public USaveGame
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY()
+    int32 integer_one;
+
+    UPROPERTY()
+    int32 integer_two;
+
+    UPROPERTY()
+    int32 integer_three;
+
+    UPROPERTY()
+    int32 integer_four;
+
+    UPROPERTY()
+    float float_one;
+
+    UPROPERTY()
+    float float_two;
+
+    UPROPERTY()
+    float float_three;
+
+    UPROPERTY()
+    FVector vector_one;
+
+    UPROPERTY()
+    FVector vector_two;
+
+    static USaveGameData* Current;
+
+    static void LoadFromFile(const FString& Path);
+    static void SaveToFile(const FString& Path);
+    static bool TryLoadFromArgs();
+};


### PR DESCRIPTION
## Summary
- add Godot implementation of SaveGameData with fields and JSON load/save
- add Unreal C++ SaveGameData class with file serialization and argument parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a3b43110833099b2f493e1ccb928